### PR TITLE
add simple user-agent control for playlist on safari

### DIFF
--- a/app/recordings/views.py
+++ b/app/recordings/views.py
@@ -17,6 +17,9 @@ class RecordingPlayListView(View):
     content_type = "application/vnd.apple.mpegurl"
     http_method_names = ['get', 'options']
 
+    def is_user_agent_safari(self, request):
+        return "safari" in request.headers.get("User-Agent", "").lower()
+
     def get(self, request, *args, **kwargs):
         recording = get_object_or_404(
             Recording,
@@ -34,7 +37,7 @@ class RecordingPlayListView(View):
         # todo: EXT-X-DISCONTINUITY seems to not be working on Safari. Leaving it out
         # renders the stream unusable on Firefox/Chrome.
         # Therefore remove EXT-X-DISCONTINUITY if the user's browser is Safari.
-        if "safari" not in request.headers.get("User-Agent", "").lower():
+        if not self.is_user_agent_safari(request):
             m3u8 += "#EXT-X-DISCONTINUITY\n"
         for chunk in sorted(recording.chunks, key=lambda c: c['position']):
             m3u8 += "\n"


### PR DESCRIPTION
added the following:

```python
if "safari" not in request.headers['User-Agent'].lower():
    m3u8 += "#EXT-X-DISCONTINUITY\n"
```